### PR TITLE
View event functions

### DIFF
--- a/examples/phone-book-app/.gitignore
+++ b/examples/phone-book-app/.gitignore
@@ -2,3 +2,4 @@
 !webpack.config.js
 *.js.map
 *.d.ts
+build/*

--- a/examples/phone-book-app/display-layer-container/index.html
+++ b/examples/phone-book-app/display-layer-container/index.html
@@ -8,6 +8,8 @@
 	</head>
 	<body>
 		<div id="main"></div>
+		<div id="second"></div>
+		<div id="standalone"></div>
 		<script src="bundle.js"></script>
 	</body>
 </html>

--- a/examples/phone-book-app/display-layer-container/index.ts
+++ b/examples/phone-book-app/display-layer-container/index.ts
@@ -5,7 +5,9 @@ import { ViewInterfacesType, viewInterfaces } from "../viewInterfaces";
 import { views } from "./views";
 import mainFlow from "../server/flows/main";
 
-const transport = new Transports.WebSocketsTransport({ port: 12345 });
+const worker = new Worker("./worker.js");
+
+const transport = new Transports.WebWorkerTransport({ worker });
 
 renderDisplayLayer({
 	element: document.getElementById("main"),

--- a/examples/phone-book-app/display-layer-container/index.ts
+++ b/examples/phone-book-app/display-layer-container/index.ts
@@ -9,8 +9,20 @@ const worker = new Worker("./worker.js");
 
 const transport = new Transports.WebWorkerTransport({ worker });
 
+const testHandler = (data) => {
+  console.log(data);
+  transport.removeWorkerEventListener("test", testHandler);
+};
+
+transport.addWorkerEventListener("test", testHandler);
+
+
 renderDisplayLayer({
 	element: document.getElementById("main"),
 	transport,
 	views,
 });
+
+transport.emitWorkerEvent("test", "hello from display test"); // should only get one message
+transport.emitWorkerEvent("test", "hello from display test");
+transport.emitWorkerEvent("test", "hello from display test");

--- a/examples/phone-book-app/display-layer-container/index.ts
+++ b/examples/phone-book-app/display-layer-container/index.ts
@@ -3,26 +3,26 @@ import { renderDisplayLayer } from "@mcesystems/reflow-react-display-layer";
 
 import { ViewInterfacesType, viewInterfaces } from "../viewInterfaces";
 import { views } from "./views";
-import mainFlow from "../server/flows/main";
 
-const worker = new Worker("./worker.js");
 
-const transport = new Transports.WebWorkerTransport({ worker });
+const transport = new Transports.WebWorkerTransport({ connection: new BroadcastChannel("main_service") });
 
 const testHandler = (data) => {
-  console.log(data);
-  transport.removeWorkerEventListener("test", testHandler);
+	console.log(data);
+	transport.removeWorkerEventListener("test", testHandler);
 };
 
-transport.addWorkerEventListener("test", testHandler);
-
-
-renderDisplayLayer({
-	element: document.getElementById("main"),
-	transport,
-	views,
-});
-
-transport.emitWorkerEvent("test", "hello from display test"); // should only get one message
-transport.emitWorkerEvent("test", "hello from display test");
-transport.emitWorkerEvent("test", "hello from display test");
+navigator.serviceWorker.register('./worker.js').then(() => {
+	transport.addWorkerEventListener("test", testHandler);
+	
+	
+	renderDisplayLayer({
+		element: document.getElementById("main"),
+		transport,
+		views,
+	});
+	
+	transport.emitWorkerEvent("test", "hello from display test"); // should only get one message
+	transport.emitWorkerEvent("test", "hello from display test");
+	transport.emitWorkerEvent("test", "hello from display test");
+})

--- a/examples/phone-book-app/display-layer-container/index.ts
+++ b/examples/phone-book-app/display-layer-container/index.ts
@@ -6,9 +6,23 @@ import { views } from "./views";
 import mainFlow from "../server/flows/main";
 
 const transport = new Transports.WebSocketsTransport({ port: 12345 });
+const transportSecond = new Transports.WebSocketsTransport({ port: 12345, path: "/second" });
+const transportStandalone = new Transports.WebSocketsTransport({ port: 12346 });
 
 renderDisplayLayer({
 	element: document.getElementById("main"),
 	transport,
+	views,
+});
+
+renderDisplayLayer({
+	element: document.getElementById("second"),
+	transport: transportSecond,
+	views,
+});
+
+renderDisplayLayer({
+	element: document.getElementById("standalone"),
+	transport: transportStandalone,
 	views,
 });

--- a/examples/phone-book-app/display-layer-container/views/ContactsList.tsx
+++ b/examples/phone-book-app/display-layer-container/views/ContactsList.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 
 class ContactsList extends ReflowReactComponent<ContactsListInterface> {
 	render() {
-		const { title, contacts, event } = this.props;
+		const { title, contacts, event, call } = this.props;
 		return (
 			<div
 				style={{
@@ -40,6 +40,7 @@ class ContactsList extends ReflowReactComponent<ContactsListInterface> {
 									<div>{email}</div>
 								</div>
 								<button onClick={() => event("editContact", { id })}>Edit</button>
+								<button onClick={() => call("deleteContact", { id }).then((value) => alert(value ? "contact deleted" : "fail to delete contact"))}>Delete</button>
 							</div>
 						))
 					}

--- a/examples/phone-book-app/display-layer-container/views/ContactsList.tsx
+++ b/examples/phone-book-app/display-layer-container/views/ContactsList.tsx
@@ -9,7 +9,7 @@ class ContactsList extends ReflowReactComponent<ContactsListInterface> {
 			<div
 				style={{
 					width: 512,
-					height: "100%",
+					height: "50%",
 					borderRadius: 5,
 					margin: "auto"
 				}}

--- a/examples/phone-book-app/display-layer-container/views/ContactsList.tsx
+++ b/examples/phone-book-app/display-layer-container/views/ContactsList.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 
 class ContactsList extends ReflowReactComponent<ContactsListInterface> {
 	render() {
-		const { title, contacts, event, call } = this.props;
+		const { title, contacts, event, } = this.props;
 		return (
 			<div
 				style={{
@@ -40,7 +40,7 @@ class ContactsList extends ReflowReactComponent<ContactsListInterface> {
 									<div>{email}</div>
 								</div>
 								<button onClick={() => event("editContact", { id })}>Edit</button>
-								<button onClick={() => call("deleteContact", { id }).then((value) => alert(value ? "contact deleted" : "fail to delete contact"))}>Delete</button>
+								<button onClick={() => event("deleteContact", { id }).then((value) => alert(value ? "contact deleted" : "fail to delete contact"))}>Delete</button>
 							</div>
 						))
 					}

--- a/examples/phone-book-app/package.json
+++ b/examples/phone-book-app/package.json
@@ -5,7 +5,8 @@
 	"description": "A form filling wizard demonstrating a Reflow with a server-client connection",
 	"main": "dist/index",
 	"scripts": {
-		"build": "tsc && cd ./display-layer-container && webpack && cd .."
+		"build": "tsc && cd ./display-layer-container && webpack && cd ..",
+		"dev:web": "cd ./display-layer-container && webpack-dev-server && cd .."
 	},
 	"author": "mceSystems",
 	"dependencies": {

--- a/examples/phone-book-app/package.json
+++ b/examples/phone-book-app/package.json
@@ -5,7 +5,9 @@
 	"description": "A form filling wizard demonstrating a Reflow with a server-client connection",
 	"main": "dist/index",
 	"scripts": {
-		"build": "tsc && cd ./display-layer-container && webpack && cd .."
+		"build-web": "cd ./display-layer-container && webpack && cp index.html ../build && cd ..",
+		"build-server": "cd ./server && webpack && cd ..",
+		"build": "npm run build-server && npm run build-web"
 	},
 	"author": "mceSystems",
 	"dependencies": {

--- a/examples/phone-book-app/server/flows/editContact.ts
+++ b/examples/phone-book-app/server/flows/editContact.ts
@@ -4,7 +4,7 @@ import { ViewInterfacesType } from "../../viewInterfaces";
 import Contact from "../../viewInterfaces/shared/Contact";
 
 export type FlowInput = {
-	contact: Contact
+	contact?: Contact
 };
 export default <Flow<ViewInterfacesType, FlowInput, Contact>>(async ({ view, views, input: { contact = { name: "", phoneNumber: "" } } }) => {
 	const nameOutput = await view(0, views.EditContactField, {

--- a/examples/phone-book-app/server/flows/main.ts
+++ b/examples/phone-book-app/server/flows/main.ts
@@ -4,9 +4,11 @@ import { ViewInterfacesType } from "../../viewInterfaces";
 import { ContactListEntry } from "../../viewInterfaces/ContactsList";
 
 import editContact from "./editContact";
+import { transport } from "..";
 
 export default <Flow<ViewInterfacesType>>(async ({ view, views, flow }) => {
 	console.log("Entered main flow");
+	transport.emitWorkerEvent("test", "hello test");
 
 	const contacts: ContactListEntry[] = [];
 	const contactList = view(0, views.ContactsList, {

--- a/examples/phone-book-app/server/flows/main.ts
+++ b/examples/phone-book-app/server/flows/main.ts
@@ -13,7 +13,7 @@ export default <Flow<ViewInterfacesType>>(async ({ view, views, flow }) => {
 		contacts,
 		title: "My Contacts"
 	})
-		.implement("deleteContact", async ({ id }) => {
+		.on("deleteContact", async ({ id }) => {
 			if (contacts.find((contact) => contact.id === id)) {
 				contacts = contacts.filter((contact) => contact.id !== id);
 				contactList.update({ contacts });

--- a/examples/phone-book-app/server/flows/main.ts
+++ b/examples/phone-book-app/server/flows/main.ts
@@ -8,14 +8,24 @@ import editContact from "./editContact";
 export default <Flow<ViewInterfacesType>>(async ({ view, views, flow }) => {
 	console.log("Entered main flow");
 
-	const contacts: ContactListEntry[] = [];
+	let contacts: ContactListEntry[] = [];
 	const contactList = view(0, views.ContactsList, {
 		contacts,
 		title: "My Contacts"
 	})
+		.implement("deleteContact", async ({ id }) => {
+			if (contacts.find((contact) => contact.id === id)) {
+				contacts = contacts.filter((contact) => contact.id !== id);
+				contactList.update({ contacts });
+				return true;
+			} else {
+				return false;
+			}
+		})
 		.on("newContact", async () => {
 			console.log("Got new contact request");
-			const newContact = await flow(editContact, {}) as ContactListEntry;
+			// @ts-ignore
+			const newContact = await flow(editContact, { }) as ContactListEntry;
 			newContact.id = `contact-${Math.random()}`;
 			console.log(`Created contact ${newContact.id}`);
 			contacts.push(newContact);

--- a/examples/phone-book-app/server/flows/main.ts
+++ b/examples/phone-book-app/server/flows/main.ts
@@ -15,6 +15,7 @@ export default <Flow<ViewInterfacesType>>(async ({ view, views, flow }) => {
 	})
 		.on("newContact", async () => {
 			console.log("Got new contact request");
+			// @ts-ignore
 			const newContact = await flow(editContact, {}) as ContactListEntry;
 			newContact.id = `contact-${Math.random()}`;
 			console.log(`Created contact ${newContact.id}`);

--- a/examples/phone-book-app/server/index.ts
+++ b/examples/phone-book-app/server/index.ts
@@ -2,7 +2,7 @@ import { Transports, Reflow } from "@mcesystems/reflow";
 import { ViewInterfacesType, viewInterfaces } from "../viewInterfaces";
 import mainFlow from "./flows/main";
 
-export const transport = new Transports.WebWorkerTransport({});
+export const transport = new Transports.WebWorkerTransport({ connection: new BroadcastChannel("main_service") });
 
 const testHandler = (data) => {
   console.log(data);

--- a/examples/phone-book-app/server/index.ts
+++ b/examples/phone-book-app/server/index.ts
@@ -2,7 +2,7 @@ import { Transports, Reflow } from "@mcesystems/reflow";
 import { ViewInterfacesType, viewInterfaces } from "../viewInterfaces";
 import mainFlow from "./flows/main";
 
-const transport = new Transports.WebSocketsTransport({ port: 12345 });
+const transport = new Transports.WebWorkerTransport({});
 
 const reflow = new Reflow<ViewInterfacesType>({
 	transport,

--- a/examples/phone-book-app/server/index.ts
+++ b/examples/phone-book-app/server/index.ts
@@ -1,11 +1,32 @@
 import { Transports, Reflow } from "@mcesystems/reflow";
 import { ViewInterfacesType, viewInterfaces } from "../viewInterfaces";
 import mainFlow from "./flows/main";
+import { createServer } from 'http'
 
-const transport = new Transports.WebSocketsTransport({ port: 12345 });
+const server = createServer();
+server.listen(12345);
+
+const transport = new Transports.WebSocketsTransport({}, server);
+const transportSecond = new Transports.WebSocketsTransport({ path: "/second" }, server);
+const transportStandalone = new Transports.WebSocketsTransport({ port: 12346 });
 
 const reflow = new Reflow<ViewInterfacesType>({
 	transport,
 	views: viewInterfaces,
 });
+
 reflow.start(mainFlow)
+
+const reflowSecond = new Reflow<ViewInterfacesType>({
+	transport: transportSecond,
+	views: viewInterfaces,
+});
+
+reflowSecond.start(mainFlow)
+
+const reflowStandalone = new Reflow<ViewInterfacesType>({
+	transport: transportStandalone,
+	views: viewInterfaces,
+});
+
+reflowStandalone.start(mainFlow)

--- a/examples/phone-book-app/server/index.ts
+++ b/examples/phone-book-app/server/index.ts
@@ -2,10 +2,19 @@ import { Transports, Reflow } from "@mcesystems/reflow";
 import { ViewInterfacesType, viewInterfaces } from "../viewInterfaces";
 import mainFlow from "./flows/main";
 
-const transport = new Transports.WebWorkerTransport({});
+export const transport = new Transports.WebWorkerTransport({});
+
+const testHandler = (data) => {
+  console.log(data);
+  transport.removeWorkerEventListener("test", testHandler);
+};
+
+transport.addWorkerEventListener("test", testHandler);
+
 
 const reflow = new Reflow<ViewInterfacesType>({
 	transport,
 	views: viewInterfaces,
 });
+
 reflow.start(mainFlow)

--- a/examples/phone-book-app/server/webpack.config.js
+++ b/examples/phone-book-app/server/webpack.config.js
@@ -3,7 +3,7 @@ const path = require("path");
 module.exports = {
 	entry: "./index.ts",
 	output: {
-		filename: "bundle.js",
+		filename: "worker.js",
 		path: path.join(__dirname, "../build/"),
 	},
 	devtool: "source-map",

--- a/examples/phone-book-app/viewInterfaces/ContactsList.ts
+++ b/examples/phone-book-app/viewInterfaces/ContactsList.ts
@@ -15,4 +15,8 @@ export interface Events {
 	newContact: {}
 }
 
-export default interface ContactsList extends ViewInterface<Input, Events> { }
+export interface Functions {
+	deleteContact: (params: { id: string }) => Promise<boolean>;
+}
+
+export default interface ContactsList extends ViewInterface<Input, Events, void, Functions> { }

--- a/examples/phone-book-app/viewInterfaces/ContactsList.ts
+++ b/examples/phone-book-app/viewInterfaces/ContactsList.ts
@@ -13,10 +13,7 @@ export interface Events {
 		id: string
 	}
 	newContact: {}
-}
-
-export interface Functions {
 	deleteContact: (params: { id: string }) => Promise<boolean>;
 }
 
-export default interface ContactsList extends ViewInterface<Input, Events, void, Functions> { }
+export default interface ContactsList extends ViewInterface<Input, Events, void> { }

--- a/packages/reflow-react-display-layer/src/ReflowDisplayLayer.ts
+++ b/packages/reflow-react-display-layer/src/ReflowDisplayLayer.ts
@@ -26,7 +26,6 @@ export default class ReflowDisplayLayer<ViewMap extends ViewsMapInterface> exten
 				children: this.viewTreeToElements(view.children),
 				done: this.props.transport.sendViewDone.bind(this.props.transport, view.uid),
 				event: this.props.transport.sendViewEvent.bind(this.props.transport, view.uid),
-				call: this.props.transport.sendViewFunction.bind(this.props.transport, view.uid),
 			}, view.input);
 			return React.createElement(Component, input);
 		});

--- a/packages/reflow-react-display-layer/src/ReflowDisplayLayer.ts
+++ b/packages/reflow-react-display-layer/src/ReflowDisplayLayer.ts
@@ -26,6 +26,7 @@ export default class ReflowDisplayLayer<ViewMap extends ViewsMapInterface> exten
 				children: this.viewTreeToElements(view.children),
 				done: this.props.transport.sendViewDone.bind(this.props.transport, view.uid),
 				event: this.props.transport.sendViewEvent.bind(this.props.transport, view.uid),
+				call: this.props.transport.sendViewFunction.bind(this.props.transport, view.uid),
 			}, view.input);
 			return React.createElement(Component, input);
 		});

--- a/packages/reflow-react-display-layer/src/ReflowReactComponent.tsx
+++ b/packages/reflow-react-display-layer/src/ReflowReactComponent.tsx
@@ -1,10 +1,6 @@
 import * as React from "react";
 import { ViewInterface, ParamsUnpack, ReturnUnpack, PromiseUnpacked } from "@mcesystems/reflow";
 
-type Unpacked<T> = // unpack if promise
-    T extends Promise<infer U> ? U :
-    T;
-
 export type ReflowReactComponentProps<T extends ViewInterface<any, any, any>, ExternalProps = void> = T["input"] & {
 	children?: React.ReactNode[],
 	event: <U extends keyof T["events"]>(eventName: U, eventData: ParamsUnpack<T["events"][U]>) => Promise<PromiseUnpacked<ReturnUnpack<T["events"][U]>>>;

--- a/packages/reflow-react-display-layer/src/ReflowReactComponent.tsx
+++ b/packages/reflow-react-display-layer/src/ReflowReactComponent.tsx
@@ -1,10 +1,15 @@
 import * as React from "react";
 import { ViewInterface } from "@mcesystems/reflow";
 
-export type ReflowReactComponentProps<T extends ViewInterface<any, any, any>, ExternalProps = void> = T["input"] & {
+type Unpacked<T> = // unpack if promise
+    T extends Promise<infer U> ? U :
+    T;
+
+export type ReflowReactComponentProps<T extends ViewInterface<any, any, any, any>, ExternalProps = void> = T["input"] & {
 	children?: React.ReactNode[],
 	event: <U extends keyof T["events"]>(eventName: U, eventData: T["events"][U]) => void;
 	done: (output: T["output"]) => void;
+	call: <U extends keyof T["functions"]>(functionName: U, functionData: Parameters<T["functions"][U]>[0]) => Promise<Unpacked<ReturnType<T["functions"][U]>>>;
 } & ExternalProps;
 
 export type ReflowReactComponentClass<T extends ViewInterface<any, any, any>, ExternalProps = void, State = never>

--- a/packages/reflow-react-display-layer/src/ReflowReactComponent.tsx
+++ b/packages/reflow-react-display-layer/src/ReflowReactComponent.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ViewInterface, ParamsUnpack, ReturnUnpack } from "@mcesystems/reflow";
+import { ViewInterface, ParamsUnpack, ReturnUnpack, PromiseUnpacked } from "@mcesystems/reflow";
 
 type Unpacked<T> = // unpack if promise
     T extends Promise<infer U> ? U :
@@ -7,7 +7,7 @@ type Unpacked<T> = // unpack if promise
 
 export type ReflowReactComponentProps<T extends ViewInterface<any, any, any>, ExternalProps = void> = T["input"] & {
 	children?: React.ReactNode[],
-	event: <U extends keyof T["events"]>(eventName: U, eventData: ParamsUnpack<T["events"][U]>) => ReturnUnpack<T["events"][U]>;
+	event: <U extends keyof T["events"]>(eventName: U, eventData: ParamsUnpack<T["events"][U]>) => Promise<PromiseUnpacked<ReturnUnpack<T["events"][U]>>>;
 	done: (output: T["output"]) => void;
 } & ExternalProps;
 

--- a/packages/reflow-react-display-layer/src/ReflowReactComponent.tsx
+++ b/packages/reflow-react-display-layer/src/ReflowReactComponent.tsx
@@ -1,15 +1,14 @@
 import * as React from "react";
-import { ViewInterface } from "@mcesystems/reflow";
+import { ViewInterface, ParamsUnpack, ReturnUnpack } from "@mcesystems/reflow";
 
 type Unpacked<T> = // unpack if promise
     T extends Promise<infer U> ? U :
     T;
 
-export type ReflowReactComponentProps<T extends ViewInterface<any, any, any, any>, ExternalProps = void> = T["input"] & {
+export type ReflowReactComponentProps<T extends ViewInterface<any, any, any>, ExternalProps = void> = T["input"] & {
 	children?: React.ReactNode[],
-	event: <U extends keyof T["events"]>(eventName: U, eventData: T["events"][U]) => void;
+	event: <U extends keyof T["events"]>(eventName: U, eventData: ParamsUnpack<T["events"][U]>) => ReturnUnpack<T["events"][U]>;
 	done: (output: T["output"]) => void;
-	call: <U extends keyof T["functions"]>(functionName: U, functionData: Parameters<T["functions"][U]>[0]) => Promise<Unpacked<ReturnType<T["functions"][U]>>>;
 } & ExternalProps;
 
 export type ReflowReactComponentClass<T extends ViewInterface<any, any, any>, ExternalProps = void, State = never>

--- a/packages/reflow/package.json
+++ b/packages/reflow/package.json
@@ -20,6 +20,7 @@
 	},
 	"devDependencies": {
 		"@types/uuid": "^3.4.3",
+		"@types/node": "12.0.0",
 		"typescript": "^3.2.4"
 	},
 	"publishConfig": {

--- a/packages/reflow/src/Reflow.ts
+++ b/packages/reflow/src/Reflow.ts
@@ -136,6 +136,12 @@ export class Reflow<ViewsMap extends ViewsMapInterface, ViewerParameters = {}> {
 			}
 			this.viewMap[uid].viewProxy.event(eventName, eventData);
 		});
+		this.transport.onViewFunction((uid, functionName, functionData) => {
+			if (!this.viewMap[uid]) {
+				return;
+			}
+			return this.viewMap[uid].viewProxy.call(functionName, functionData);
+		});
 		this.viewerParameters = viewerParameters;
 		this.transport.onSyncView(() => {
 			this.updateViewerParameters(this.viewerParameters);

--- a/packages/reflow/src/Reflow.ts
+++ b/packages/reflow/src/Reflow.ts
@@ -134,13 +134,7 @@ export class Reflow<ViewsMap extends ViewsMapInterface, ViewerParameters = {}> {
 			if (!this.viewMap[uid]) {
 				return;
 			}
-			this.viewMap[uid].viewProxy.event(eventName, eventData);
-		});
-		this.transport.onViewFunction((uid, functionName, functionData) => {
-			if (!this.viewMap[uid]) {
-				return;
-			}
-			return this.viewMap[uid].viewProxy.call(functionName, functionData);
+			return this.viewMap[uid].viewProxy.event(eventName, eventData);
 		});
 		this.viewerParameters = viewerParameters;
 		this.transport.onSyncView(() => {

--- a/packages/reflow/src/Transports/Implementations/InProcTransport.ts
+++ b/packages/reflow/src/Transports/Implementations/InProcTransport.ts
@@ -1,6 +1,7 @@
 import { ReflowTransport } from "../ReflowTransport";
 import { ReducedViewTree } from "../../Reflow";
 import { ViewInterface, ViewsMapInterface } from "../../View";
+import { ReturnUnpack, ParamsUnpack } from "../../ViewProxy";
 
 
 export default class InProcTransport<ViewerParameters = {}> extends ReflowTransport<ViewerParameters> {
@@ -18,16 +19,11 @@ export default class InProcTransport<ViewerParameters = {}> extends ReflowTransp
 			listener(JSON.parse(JSON.stringify(tree)));
 		}
 	}
-	sendViewEvent<T extends ViewInterface, U extends keyof T["events"]>(uid: string, eventName: U, eventData: T["events"][U]): void {
-		for (const listener of this.viewEventListeners) {
-			listener(uid, eventName, eventData);
-		}
-	}
-	sendViewFunction<T extends ViewInterface<{}, {}, {}, any>, U extends keyof T["functions"]>(uid: string, functionName: U, functionData: T["functions"][U]): Promise<ReturnType<T["functions"][U]> | undefined>{
-		return new Promise<ReturnType<T["functions"][U]>>((resolve) => {
+	sendViewEvent<T extends ViewInterface, U extends keyof T["events"]>(uid: string, eventName: U, eventData: ParamsUnpack<T["events"][U]>): Promise<ReturnUnpack<T["events"][U]>> {
+		return new Promise<ReturnUnpack<T["events"][U]>>((resolve) => {
 			let finish = false;
-			for (const listener of this.viewFunctionListeners) {
-				const result = listener(uid, functionName, functionData);
+			for (const listener of this.viewEventListeners) {
+				const result = listener(uid, eventName, eventData);
 				if (result) {
 				finish = true;
 				resolve(result);

--- a/packages/reflow/src/Transports/Implementations/InProcTransport.ts
+++ b/packages/reflow/src/Transports/Implementations/InProcTransport.ts
@@ -21,18 +21,19 @@ export default class InProcTransport<ViewerParameters = {}> extends ReflowTransp
 	}
 	sendViewEvent<T extends ViewInterface, U extends keyof T["events"]>(uid: string, eventName: U, eventData: ParamsUnpack<T["events"][U]>): Promise<ReturnUnpack<T["events"][U]>> {
 		return new Promise<ReturnUnpack<T["events"][U]>>((resolve) => {
-			let finish = false;
+			let result: ReturnUnpack<T["events"][U]>;
 			for (const listener of this.viewEventListeners) {
-				const result = listener(uid, eventName, eventData);
-				if (result) {
-				finish = true;
-				resolve(result);
+				const listenerResult = listener(uid, eventName, eventData);
+				if (listenerResult) {
+				result = listenerResult;
 			}
 		}
-		if (!finish) {
-			resolve();
-			}
-		});
+		if (result) {
+			resolve(result);
+		} else {
+			resolve()
+		}
+	});
 	}
 	sendViewDone<T extends ViewInterface>(uid: string, output: T["output"]): void {
 		for (const listener of this.viewDoneListeners) {

--- a/packages/reflow/src/Transports/Implementations/InProcTransport.ts
+++ b/packages/reflow/src/Transports/Implementations/InProcTransport.ts
@@ -23,6 +23,21 @@ export default class InProcTransport<ViewerParameters = {}> extends ReflowTransp
 			listener(uid, eventName, eventData);
 		}
 	}
+	sendViewFunction<T extends ViewInterface<{}, {}, {}, any>, U extends keyof T["functions"]>(uid: string, functionName: U, functionData: T["functions"][U]): Promise<ReturnType<T["functions"][U]> | undefined>{
+		return new Promise<ReturnType<T["functions"][U]>>((resolve) => {
+			let finish = false;
+			for (const listener of this.viewFunctionListeners) {
+				const result = listener(uid, functionName, functionData);
+				if (result) {
+				finish = true;
+				resolve(result);
+			}
+		}
+		if (!finish) {
+			resolve();
+			}
+		});
+	}
 	sendViewDone<T extends ViewInterface>(uid: string, output: T["output"]): void {
 		for (const listener of this.viewDoneListeners) {
 			listener(uid, output);

--- a/packages/reflow/src/Transports/Implementations/WebSocketsTransport.ts
+++ b/packages/reflow/src/Transports/Implementations/WebSocketsTransport.ts
@@ -9,6 +9,7 @@ import { ReturnUnpack, PromiseUnpacked, ParamsUnpack } from "../../ViewProxy";
 interface WebSocketConnectionOptions {
   host?: string;
   port?: number;
+  path?: string;
 }
 
 export default class WebSocketsTransport<
@@ -18,22 +19,25 @@ export default class WebSocketsTransport<
   private __socket: ServerSocket | ClientSocket;
   private __server?: Server;
   private requestIndex: number = 0;
-  constructor(connectionOptions: WebSocketConnectionOptions | undefined = {}, server?: Server) {
+  constructor(
+    connectionOptions: WebSocketConnectionOptions | undefined = {},
+    server?: Server
+  ) {
     super(connectionOptions);
     this.__connectionOptions = connectionOptions;
-	this.__socket = null;
-	this.__server = server;
+    this.__socket = null;
+    this.__server = server;
   }
 
   initializeAsEngine() {
-    const { port = 3000 , path = ""} = this.__connectionOptions || {};
+    const { port = 3000, path = "" } = this.__connectionOptions || {};
     if (this.__server) {
-		this.__socket = require("socket.io")(this.__server, { path });
-	} else {
-		const server = require("http").createServer();
-		this.__socket = require("socket.io")(server, { path });
-		server.listen(port);
-	}
+      this.__socket = require("socket.io")(this.__server, { path });
+    } else {
+      const server = require("http").createServer();
+      this.__socket = require("socket.io")(server, { path });
+      server.listen(port);
+    }
     this.__socket.on("connection", (socket) => {
       socket
         .on(
@@ -99,7 +103,8 @@ export default class WebSocketsTransport<
   }
   initializeAsDisplay() {
     const io = require("socket.io-client");
-    const { host = "localhost", port = 3000, path = "" } = this.__connectionOptions || {};
+    const { host = "localhost", port = 3000, path = "" } =
+      this.__connectionOptions || {};
     const socket = io(`http://${host}:${port}`, { path });
     this.__socket = socket;
     socket

--- a/packages/reflow/src/Transports/Implementations/WebSocketsTransport.ts
+++ b/packages/reflow/src/Transports/Implementations/WebSocketsTransport.ts
@@ -4,6 +4,7 @@ import { ViewInterface, ViewsMapInterface } from "../../View";
 
 import ServerSocket from "socket.io";
 import ClientSocket from "socket.io-client";
+import { ReturnUnpack, PromiseUnpacked, ParamsUnpack } from "../../ViewProxy";
 
 interface WebSocketConnectionOptions {
 	host?: string;
@@ -30,30 +31,29 @@ export default class WebSocketsTransport<ViewerParameters = {}> extends ReflowTr
 		this.__socket = io;
 		this.__socket.on("connection", (socket) => {
 			socket
-				.on("view_event", <T extends ViewInterface, U extends keyof T["events"]>({ uid, eventName, eventData }: {uid: string; eventName: U; eventData: T["events"][U]}) => {
-					for (const listener of this.viewEventListeners) {
-						listener(uid, eventName, eventData);
-					}
-				})
-				.on("view_function", <T extends ViewInterface<object, object, void, { [name: string]: any }>, U extends keyof T["functions"]>({ uid, requestId, functionName, functionData }: {uid: string; requestId: string; functionName: any; functionData: Parameters<T["functions"][U]>[0]}) => {
+				.on("view_event", <T extends ViewInterface, U extends keyof T["events"]>({ uid, requestId, eventName, eventData }: {uid: string; requestId: string; eventName: U; eventData: ParamsUnpack<T["events"][U]>}) => {
 					let finish = false;
-					for (const listener of this.viewFunctionListeners) {
-						const result = listener(uid, functionName, functionData);
+					for (const listener of this.viewEventListeners) {
+						const result = listener(uid, eventName, eventData);
 						if (result) {
 							finish = true;
 							if (Promise.resolve(result) === result) {
-								result.then((functionResult) => {
-									this.__socket.emit("view_function_result", { uid, requestId, functionResult });
+								const promiseResult = result as Promise<PromiseUnpacked<typeof result>>;
+								promiseResult.then((eventResult) => {
+									this.__socket.emit("view_event_result", { uid, requestId, eventResult });
 								}).catch(() => {
-									this.__socket.emit("view_function_result", { uid, requestId });
+									this.__socket.emit("view_event_result", { uid, requestId });
 								});
 							} else {
-								this.__socket.emit("view_function_result", { uid, requestId, functionResult: result });
+								this.__socket.emit("view_event_result", { uid, requestId, eventResult: result });
 							}
 						}
 					}
 					if (!finish) {
 						this.__socket.emit("view_function_result", { uid, requestId });
+					}
+					for (const listener of this.viewEventListeners) {
+						listener(uid, eventName, eventData);
 					}
 				})
 				.on("view_done", ({ uid, output }) => {
@@ -94,26 +94,23 @@ export default class WebSocketsTransport<ViewerParameters = {}> extends ReflowTr
 
 		return Promise.resolve(this);
 	}
-	sendViewFunction<T extends ViewInterface<{}, {}, {}, any>, U extends keyof T["functions"]>(uid: string, functionName: U, functionData: T["functions"][U]): Promise<ReturnType<T["functions"][U]> | undefined>{
-		this.requestIndex++;
-		const requestId = this.requestIndex;
-		return new Promise<ReturnType<T["functions"][U]>>((resolve) => {
-			this.__socket.on("view_function_result", (result: { uid: string, requestId: number, functionResult?: ReturnType<T["functions"][U]>}) => {
-				if (result.uid === uid, result.requestId === requestId) {
-					resolve(result.functionResult);
-				}
-			})
-			this.__socket.emit("view_function", { uid, requestId, functionName, functionData });
-		})
-	}
 	sendViewSync() {
 		this.__socket.emit("view_sync", {});
 	}
 	sendViewTree(tree: ReducedViewTree<ViewsMapInterface>) {
 		this.__socket.emit("view_tree", { tree });
 	}
-	sendViewEvent<T extends ViewInterface, U extends keyof T["events"]>(uid: string, eventName: U, eventData: T["events"][U]): void {
-		this.__socket.emit("view_event", { uid, eventName, eventData });
+	sendViewEvent<T extends ViewInterface, U extends keyof T["events"]>(uid: string, eventName: U, eventData: ParamsUnpack<T["events"][U]>): Promise<ReturnUnpack<T["events"][U]>> {
+		this.requestIndex++;
+		const requestId = this.requestIndex;
+		return new Promise<ReturnUnpack<T["events"][U]>>((resolve) => {
+			this.__socket.on("view_event_result", (result: { uid: string, requestId: number, eventResult?: ReturnUnpack<T["events"][U]>}) => {
+				if (result.uid === uid, result.requestId === requestId) {
+					resolve(result.eventResult);
+				}
+			})
+			this.__socket.emit("view_event", { uid, requestId, eventName, eventData });
+		});
 	}
 	sendViewerParameters(viewerParameters: ViewerParameters): void {
 		this.__socket.emit("viewer_parameters", { parameters: viewerParameters });

--- a/packages/reflow/src/Transports/Implementations/WebSocketsTransport.ts
+++ b/packages/reflow/src/Transports/Implementations/WebSocketsTransport.ts
@@ -43,15 +43,15 @@ export default class WebSocketsTransport<ViewerParameters = {}> extends ReflowTr
 						if (Promise.resolve(result) === result) {
 							const promiseResult = result as Promise<PromiseUnpacked<typeof result>>;
 							promiseResult.then((eventResult) => {
-								this.__socket.emit("view_event_result", { uid, requestId, eventResult });
+									socket.emit("view_event_result", { uid, requestId, eventResult });
 								}).catch(() => {
-								this.__socket.emit("view_event_result", { uid, requestId });
+									socket.emit("view_event_result", { uid, requestId });
 								});
 						} else {
-							this.__socket.emit("view_event_result", { uid, requestId, eventResult: result });
+							socket.emit("view_event_result", { uid, requestId, eventResult: result });
 						}
 					} else {
-						this.__socket.emit("view_function_result", { uid, requestId });
+						socket.emit("view_function_result", { uid, requestId });
 					}				})
 				.on("view_done", ({ uid, output }) => {
 					for (const listener of this.viewDoneListeners) {

--- a/packages/reflow/src/Transports/Implementations/WebWorkerTransport.ts
+++ b/packages/reflow/src/Transports/Implementations/WebWorkerTransport.ts
@@ -1,0 +1,132 @@
+import { ReflowTransport } from "../ReflowTransport";
+import { ReducedViewTree } from "../../Reflow";
+import { ViewInterface, ViewsMapInterface } from "../../View";
+
+interface WorkerConnectionOptions {
+  worker?: Worker;
+}
+
+interface WorkerEvent {
+  name: string;
+  data: any;
+}
+
+interface MessageClient {
+  onmessage?: (message: WorkerEvent) => void;
+  readonly postMessage: (message: WorkerEvent) => void;
+}
+
+export default class WebSocketsTransport<
+  ViewerParameters = {}
+> extends ReflowTransport<ViewerParameters> {
+  private __worker?: MessageClient;
+
+  constructor(connectionOptions: WorkerConnectionOptions) {
+    super(connectionOptions);
+    this.__worker = (connectionOptions.worker as unknown) as MessageClient;
+  }
+  initializeAsEngine() {
+    this.__worker = (self as unknown) as MessageClient;
+    const onViewEvent = <T extends ViewInterface, U extends keyof T["events"]>({
+      uid,
+      eventName,
+      eventData,
+    }: {
+      uid: string;
+      eventName: U;
+      eventData: T["events"][U];
+    }) => {
+      for (const listener of this.viewEventListeners) {
+        listener(uid, eventName, eventData);
+      }
+    };
+    const onViewDone = ({ uid, output }) => {
+      for (const listener of this.viewDoneListeners) {
+        listener(uid, output);
+      }
+    };
+    const onViewSync = (n) => {
+      for (const listener of this.viewSyncListeners) {
+        listener();
+      }
+    };
+    const onEvent = (event: WorkerEvent) => {
+      if (event.name === "view_event") {
+        onViewEvent(event.data);
+      } else if (event.name === "view_done") {
+        onViewDone(event.data);
+      } else if (event.name === "view_sync") {
+        onViewSync(event.data);
+      } else if (event.name === "connect") {
+        this.__worker.postMessage({ name: "connect", data: {} });
+      }
+    };
+    this.__worker.onmessage = (message: WorkerEvent) => {
+      onEvent(message.data);
+    };
+
+    return Promise.resolve();
+  }
+  initializeAsDisplay() {
+    const onConnect = () => {
+      this.sendViewSync();
+    };
+    const onViewTree = ({ tree }) => {
+      for (const listener of this.viewStackUpdateListeners) {
+        listener(tree);
+      }
+    };
+    const onViewerParameters = ({ parameters }) => {
+      for (const listener of this.viewerParametersListeners) {
+        listener(parameters);
+      }
+    };
+
+    const onEvent = (event: WorkerEvent) => {
+      if (event.name === "connect") {
+        onConnect();
+      } else if (event.name === "view_tree") {
+        onViewTree(event.data);
+      } else if (event.name === "viewer_parameters") {
+        onViewerParameters(event.data);
+      }
+    };
+    this.__worker.onmessage = (e) => onEvent(e.data);
+    this.__worker.postMessage({ name: "connect", data: {} });
+
+    return Promise.resolve(this);
+  }
+  sendViewSync() {
+    const event: WorkerEvent = { name: "view_sync", data: {} };
+    this.__worker.postMessage(event);
+  }
+  sendViewTree(tree: ReducedViewTree<ViewsMapInterface>) {
+    const event: WorkerEvent = { name: "view_tree", data: { tree } };
+    this.__worker.postMessage(event);
+  }
+  sendViewEvent<T extends ViewInterface, U extends keyof T["events"]>(
+    uid: string,
+    eventName: U,
+    eventData: T["events"][U]
+  ): void {
+    const event: WorkerEvent = {
+      name: "view_event",
+      data: { uid, eventName, eventData },
+    };
+    this.__worker.postMessage(event);
+  }
+  sendViewerParameters(viewerParameters: ViewerParameters): void {
+    const event: WorkerEvent = {
+      name: "viewer_parameters",
+      data: { parameters: viewerParameters },
+    };
+    this.__worker.postMessage(event);
+  }
+  sendViewDone<T extends ViewInterface>(
+    uid: string,
+    output: T["output"]
+  ): void {
+    const event: WorkerEvent = { name: "view_done", data: { uid, output } };
+    this.__worker.postMessage(event);
+  }
+}

--- a/packages/reflow/src/Transports/Implementations/WebWorkerTransport.ts
+++ b/packages/reflow/src/Transports/Implementations/WebWorkerTransport.ts
@@ -3,8 +3,15 @@ import { ReducedViewTree } from "../../Reflow";
 import { ViewInterface, ViewsMapInterface } from "../../View";
 
 interface WorkerConnectionOptions {
-  worker?: Worker;
+  /**
+   * <pre> if your using web worker please pass the Worker from the diplay layer or self from the server. </pre>
+   * <pre> if your using web service please pass a the BroadcastChannel from both the diplay layer or the server. </pre>
+   * <pre> if you want to use custom event based transport please pass a MessageClient. </pre>
+   */
+  connection: Worker | MessageClient | BroadcastChannel | Window;
 }
+
+BroadcastChannel
 
 interface WorkerEvent {
   name: string;
@@ -33,9 +40,7 @@ export default class WebSocketsTransport<
 
   constructor(connectionOptions: WorkerConnectionOptions) {
     super(connectionOptions);
-    if (connectionOptions.worker) {
-      this.__worker = (connectionOptions.worker as unknown) as MessageClient;
-    }
+    this.__worker = (connectionOptions.connection as unknown) as MessageClient;
   }
 
   public addWorkerEventListener = (
@@ -73,7 +78,6 @@ export default class WebSocketsTransport<
   };
 
   initializeAsEngine() {
-    this.__worker = (self as unknown) as MessageClient;
     const onViewEvent = <T extends ViewInterface, U extends keyof T["events"]>({
       uid,
       eventName,

--- a/packages/reflow/src/Transports/ReflowTransport.ts
+++ b/packages/reflow/src/Transports/ReflowTransport.ts
@@ -1,8 +1,8 @@
 import { ReducedViewTree } from "../Reflow";
 import { ViewInterface, ViewsMapInterface } from "../View";
+import { ReturnUnpack, ParamsUnpack } from "../ViewProxy";
 
-export type TransportViewEventListener = <T extends ViewInterface, U extends keyof T["events"]>(uid: string, eventName: U, eventData: T["events"][U]) => void;
-export type TransportViewFunctionListener = <T extends ViewInterface<object, object, void, any>, U extends keyof T["functions"]> (uid: string, functionName: U, functionData: Parameters<T["functions"][U]>[0]) => ReturnType<T["functions"][U]> | void;
+export type TransportViewEventListener = <T extends ViewInterface, U extends keyof T["events"]>(uid: string, eventName: U, eventData: ParamsUnpack<T["events"][U]>) => ReturnUnpack<T["events"][U]>;
 export type TransportViewDoneListener = <T extends ViewInterface>(uid: string, output: T["output"]) => void;
 export type TransportViewStackUpdateListener = (tree: ReducedViewTree<ViewsMapInterface>) => void;
 export type TransportViewerParametersListener<ViewerParameters = {}> = (params: ViewerParameters) => void;
@@ -10,7 +10,6 @@ export type TransportSyncViewListener = () => void;
 
 export abstract class ReflowTransport<ViewerParameters = {}> {
 	protected viewEventListeners: Array<TransportViewEventListener> = [];
-	protected viewFunctionListeners: Array<TransportViewFunctionListener> = [];
 	protected viewDoneListeners: Array<TransportViewDoneListener> = [];
 	protected viewStackUpdateListeners: Array<TransportViewStackUpdateListener> = [];
 	protected viewerParametersListeners: Array<TransportViewerParametersListener<ViewerParameters>> = [];
@@ -50,15 +49,6 @@ export abstract class ReflowTransport<ViewerParameters = {}> {
 		this.viewEventListeners.push(listener);
 	}
 	/**
-	 * Registers an function listener on a specific view's event
-	 *
-	 * @param {TransportViewFunctionListener} listener function callback
-	 * @memberof ReflowTransport
-	 */
-	onViewFunction(listener: TransportViewFunctionListener): void {
-		this.viewFunctionListeners.push(listener);
-	}
-	/**
 	 * Registers a listener for views' done invocation, to get their output
 	 *
 	 * @param {TransportViewDoneListener} listener Callback to receive the uid and the view's output
@@ -93,7 +83,7 @@ export abstract class ReflowTransport<ViewerParameters = {}> {
 		this.viewStackUpdateListeners.push(listener);
 	}
 	/**
-	 * Sends a view event from the display to the engine
+	 * Sends a view event from the display to the engine and return last event result
 	 *
 	 * @template T
 	 * @template U
@@ -102,18 +92,7 @@ export abstract class ReflowTransport<ViewerParameters = {}> {
 	 * @param {T["events"][U]} eventData
 	 * @memberof ReflowTransport
 	 */
-	abstract sendViewEvent<T extends ViewInterface, U extends keyof T["events"]>(uid: string, eventName: U, eventData: T["events"][U]): void;
-	/**
-	 * Sends a view function from the display to the engine
-	 *
-	 * @template T
-	 * @template U
-	 * @param {string} uid
-	 * @param {U} functionName
-	 * @param {T["events"][U]} functionData
-	 * @memberof ReflowTransport
-	 */
-	abstract sendViewFunction<T extends ViewInterface<{}, {}, {}, any>, U extends keyof T["functions"]>(uid: string, functionName: U, functionData: T["functions"][U]): Promise<ReturnType<T["functions"][U]> | undefined>;
+	abstract sendViewEvent<T extends ViewInterface, U extends keyof T["events"]>(uid: string, eventName: U, eventData: ParamsUnpack<T["events"][U]>): Promise<ReturnUnpack<T["events"][U]>>;
 	/**
 	 * Sends a view done from the display to the engine, along with the view's output
 	 *

--- a/packages/reflow/src/Transports/index.ts
+++ b/packages/reflow/src/Transports/index.ts
@@ -1,8 +1,10 @@
 import InProcTransport from "./Implementations/InProcTransport";
 import WebSocketsTransport from "./Implementations/WebSocketsTransport";
+import WebWorkerTransport from './Implementations/WebWorkerTransport'
 
 export * from "./ReflowTransport";
 export const Transports = {
 	InProcTransport,
 	WebSocketsTransport,
+	WebWorkerTransport,
 };

--- a/packages/reflow/src/View.ts
+++ b/packages/reflow/src/View.ts
@@ -1,9 +1,10 @@
-export interface ViewInterface<Input extends object = {}, Events extends object = {}, Output extends any = void> {
+export interface ViewInterface<Input extends object = {}, Events extends object = {}, Output extends any = void, Functions extends Record<keyof Functions, (prameters: object) => any> = {}> {
 	input: Input;
 	output: Output;
 	events: Events;
+	functions: Functions;
 }
 
 export interface ViewsMapInterface {
-	[key: string]: ViewInterface<any, any, any>;
+	[key: string]: ViewInterface<any, any, any, any>;
 }

--- a/packages/reflow/src/View.ts
+++ b/packages/reflow/src/View.ts
@@ -1,10 +1,9 @@
-export interface ViewInterface<Input extends object = {}, Events extends object = {}, Output extends any = void, Functions extends Record<keyof Functions, (prameters: object) => any> = {}> {
+export interface ViewInterface<Input extends object = {}, Events extends object = {}, Output extends any = void> {
 	input: Input;
 	output: Output;
 	events: Events;
-	functions: Functions;
 }
 
 export interface ViewsMapInterface {
-	[key: string]: ViewInterface<any, any, any, any>;
+	[key: string]: ViewInterface<any, any, any>;
 }

--- a/packages/reflow/src/ViewProxy.ts
+++ b/packages/reflow/src/ViewProxy.ts
@@ -4,13 +4,20 @@ export type PartialViewInterfaceInput<ViewsMap extends ViewsMapInterface, T exte
 	[U in keyof T["input"]]?: T["input"][U]
 };
 
-export type ViewInterfaceEvents<ViewsMap extends ViewsMapInterface, T extends ViewsMap[keyof ViewsMap]> = keyof T["events"];
-export type ViewInterfaceEventData<ViewsMap extends ViewsMapInterface, T extends ViewsMap[keyof ViewsMap], U extends ViewInterfaceEvents<ViewsMap, T>> = T["events"][U];
-export type ViewInterfaceEventCallback<ViewsMap extends ViewsMapInterface, T extends ViewsMap[keyof ViewsMap], U extends ViewInterfaceEvents<ViewsMap, T>> = (data: ViewInterfaceEventData<ViewsMap, T, U>) => void;
+export type ParamsUnpack<T> = T extends (params: infer U) => any ? U :
+    T;
 
-export type ViewInterfaceFunctions<ViewsMap extends ViewsMapInterface, T extends ViewsMap[keyof ViewsMap]> = keyof T["functions"];
-export type ViewInterfaceFunctionsReturnType<ViewsMap extends ViewsMapInterface, T extends ViewsMap[keyof ViewsMap], U extends ViewInterfaceFunctions<ViewsMap, T>> = ReturnType<T["functions"][U]>;
-export type ViewInterfaceFunctionsArguments<ViewsMap extends ViewsMapInterface, T extends ViewsMap[keyof ViewsMap], U extends ViewInterfaceFunctions<ViewsMap, T>> = Parameters<T["functions"][U]>[0];
+export type ReturnUnpack<T> = T extends (params: any) => infer U ? U :
+	void;
+
+export type PromiseUnpacked<T> =
+    T extends Promise<infer U> ? U :
+    T;
+
+export type ViewInterfaceEvents<ViewsMap extends ViewsMapInterface, T extends ViewsMap[keyof ViewsMap]> = keyof T["events"];
+export type ViewInterfaceEventData<ViewsMap extends ViewsMapInterface, T extends ViewsMap[keyof ViewsMap], U extends ViewInterfaceEvents<ViewsMap, T>> = ParamsUnpack<T["events"][U]>;
+export type ViewInterfaceEventCallback<ViewsMap extends ViewsMapInterface, T extends ViewsMap[keyof ViewsMap], U extends ViewInterfaceEvents<ViewsMap, T>> = (data: ViewInterfaceEventData<ViewsMap, T, U>) => ReturnUnpack<T["events"][U]>;
+
 
 export type ViewOnUpdateCallback<ViewsMap extends ViewsMapInterface, T extends ViewsMap[keyof ViewsMap]> = (input: PartialViewInterfaceInput<ViewsMap, T>) => void;
 export type ViewOnRemoveCallback = () => void;
@@ -21,9 +28,6 @@ export class ViewProxy<ViewsMap extends ViewsMapInterface, T extends ViewsMap[ke
 	private removed: boolean = false;
 	private eventListeners: {
 		[U in ViewInterfaceEvents<ViewsMap, T>]?: Array<ViewInterfaceEventCallback<ViewsMap, T, U>>
-	};
-	private functionsListeners: {
-		[U in ViewInterfaceFunctions<ViewsMap, T>]?: (args: ViewInterfaceFunctionsArguments<ViewsMap, T, U>) => ViewInterfaceFunctionsReturnType<ViewsMap, T, U>;
 	};
 	private resolve: (output: T["output"]) => void;
 	private reject: (output: Error) => void = (output) => { };
@@ -44,7 +48,6 @@ export class ViewProxy<ViewsMap extends ViewsMapInterface, T extends ViewsMap[ke
 		this.onUpdate = onUpdate || this.onUpdate;
 		this.onRemove = onRemove || this.onRemove;
 		this.eventListeners = {};
-		this.functionsListeners = {};
 	}
 	done(output: T["output"]) {
 		if (!this.resolve) {
@@ -61,8 +64,15 @@ export class ViewProxy<ViewsMap extends ViewsMapInterface, T extends ViewsMap[ke
 		if (!this.eventListeners[eventName]) {
 			return;
 		}
+		let result: ReturnUnpack<T["events"][U]>;
 		for (const listener of this.eventListeners[eventName]) {
-			listener(data);
+			const listenerResult = listener(data);
+			if (listenerResult) {
+				result = listenerResult;
+			}
+		}
+		if (result) {
+			return result;
 		}
 	}
 	on<U extends ViewInterfaceEvents<ViewsMap, T>>(eventName: U, listener: ViewInterfaceEventCallback<ViewsMap, T, U>): ViewProxy<ViewsMap, T> {
@@ -73,23 +83,6 @@ export class ViewProxy<ViewsMap extends ViewsMapInterface, T extends ViewsMap[ke
 			this.eventListeners[eventName] = [];
 		}
 		this.eventListeners[eventName].push(listener);
-		return this;
-	}
-	call<U extends ViewInterfaceFunctions<ViewsMap, T>>(functionName: U, data: ViewInterfaceFunctionsArguments<ViewsMap, T, U>): ViewInterfaceFunctionsReturnType<ViewsMap, T, U> | void {
-		if (this.removed) {
-			return;
-		}
-		const implementations = this.functionsListeners[functionName];
-		if (!implementations) {
-			return;
-		}
-		return implementations(data);
-	}
-	implement<U extends ViewInterfaceFunctions<ViewsMap, T>>(functionName: U, implementation: (args: ViewInterfaceFunctionsArguments<ViewsMap, T, U>) => ViewInterfaceFunctionsReturnType<ViewsMap, T, U>) {
-		if (this.removed) {
-			return;
-		}
-		this.functionsListeners[functionName] = implementation;
 		return this;
 	}
 	update(params: PartialViewInterfaceInput<ViewsMap, T>) {

--- a/packages/reflow/src/ViewProxy.ts
+++ b/packages/reflow/src/ViewProxy.ts
@@ -8,6 +8,10 @@ export type ViewInterfaceEvents<ViewsMap extends ViewsMapInterface, T extends Vi
 export type ViewInterfaceEventData<ViewsMap extends ViewsMapInterface, T extends ViewsMap[keyof ViewsMap], U extends ViewInterfaceEvents<ViewsMap, T>> = T["events"][U];
 export type ViewInterfaceEventCallback<ViewsMap extends ViewsMapInterface, T extends ViewsMap[keyof ViewsMap], U extends ViewInterfaceEvents<ViewsMap, T>> = (data: ViewInterfaceEventData<ViewsMap, T, U>) => void;
 
+export type ViewInterfaceFunctions<ViewsMap extends ViewsMapInterface, T extends ViewsMap[keyof ViewsMap]> = keyof T["functions"];
+export type ViewInterfaceFunctionsReturnType<ViewsMap extends ViewsMapInterface, T extends ViewsMap[keyof ViewsMap], U extends ViewInterfaceFunctions<ViewsMap, T>> = ReturnType<T["functions"][U]>;
+export type ViewInterfaceFunctionsArguments<ViewsMap extends ViewsMapInterface, T extends ViewsMap[keyof ViewsMap], U extends ViewInterfaceFunctions<ViewsMap, T>> = Parameters<T["functions"][U]>[0];
+
 export type ViewOnUpdateCallback<ViewsMap extends ViewsMapInterface, T extends ViewsMap[keyof ViewsMap]> = (input: PartialViewInterfaceInput<ViewsMap, T>) => void;
 export type ViewOnRemoveCallback = () => void;
 
@@ -17,6 +21,9 @@ export class ViewProxy<ViewsMap extends ViewsMapInterface, T extends ViewsMap[ke
 	private removed: boolean = false;
 	private eventListeners: {
 		[U in ViewInterfaceEvents<ViewsMap, T>]?: Array<ViewInterfaceEventCallback<ViewsMap, T, U>>
+	};
+	private functionsListeners: {
+		[U in ViewInterfaceFunctions<ViewsMap, T>]?: (args: ViewInterfaceFunctionsArguments<ViewsMap, T, U>) => ViewInterfaceFunctionsReturnType<ViewsMap, T, U>;
 	};
 	private resolve: (output: T["output"]) => void;
 	private reject: (output: Error) => void = (output) => { };
@@ -37,6 +44,7 @@ export class ViewProxy<ViewsMap extends ViewsMapInterface, T extends ViewsMap[ke
 		this.onUpdate = onUpdate || this.onUpdate;
 		this.onRemove = onRemove || this.onRemove;
 		this.eventListeners = {};
+		this.functionsListeners = {};
 	}
 	done(output: T["output"]) {
 		if (!this.resolve) {
@@ -65,6 +73,23 @@ export class ViewProxy<ViewsMap extends ViewsMapInterface, T extends ViewsMap[ke
 			this.eventListeners[eventName] = [];
 		}
 		this.eventListeners[eventName].push(listener);
+		return this;
+	}
+	call<U extends ViewInterfaceFunctions<ViewsMap, T>>(functionName: U, data: ViewInterfaceFunctionsArguments<ViewsMap, T, U>): ViewInterfaceFunctionsReturnType<ViewsMap, T, U> | void {
+		if (this.removed) {
+			return;
+		}
+		const implementations = this.functionsListeners[functionName];
+		if (!implementations) {
+			return;
+		}
+		return implementations(data);
+	}
+	implement<U extends ViewInterfaceFunctions<ViewsMap, T>>(functionName: U, implementation: (args: ViewInterfaceFunctionsArguments<ViewsMap, T, U>) => ViewInterfaceFunctionsReturnType<ViewsMap, T, U>) {
+		if (this.removed) {
+			return;
+		}
+		this.functionsListeners[functionName] = implementation;
 		return this;
 	}
 	update(params: PartialViewInterfaceInput<ViewsMap, T>) {


### PR DESCRIPTION
events can now be functions 

Example: 

```
interface Events {
   stringEvent: string;
   objectEvent: { id: string };
   functionEvent: (prams: { name: string }) => string; // new
}

event("stringEvent", "hello world").then(() => console.log("event finished"));
event("objectEvent", { id: "hello world" }).then(() => console.log("event finished"));
event("functionEvent", { name: "shmuel" }).then((stringResult) => console.log(`event function return ${stringResult}`)); // new
```